### PR TITLE
Learning materials corrections

### DIFF
--- a/learning-materials/00_overview.ipynb
+++ b/learning-materials/00_overview.ipynb
@@ -29,9 +29,7 @@
    "cell_type": "markdown",
    "id": "f7a56275",
    "metadata": {},
-   "source": [
-    "The learning materials introduce basic concepts underlying OpenAI's Whisper model. The focus of this notebook is to explain how the training data is processed in the course of the training of Whisper. The training data can be divided into input data (i.e., audios) and output data (i.e., textual transcriptions), whereby the first notebook focuses the processing of the audio and the second and third notebooks focus on the processing of text."
-   ]
+   "source": "The learning materials introduce basic concepts underlying OpenAI's Whisper model. The focus of this notebook is to explain how the training data is processed in the course of the training of Whisper. The training data can be divided into input data (i.e., audios) and output data (i.e., textual transcriptions), whereby the first notebook focuses on the processing of the audio and the second and third notebooks focus on the processing of text."
   },
   {
    "cell_type": "markdown",

--- a/learning-materials/01_digital_signal_processing.ipynb
+++ b/learning-materials/01_digital_signal_processing.ipynb
@@ -31,7 +31,7 @@
     "\n",
     "From a physical perspective, spoken words are **pressure waves** that usually travel through the air. These sound waves vary in **frequency** (related to pitch) and **amplitude** (related to loudness). The complexity of these variations carries the rich information of human language.\n",
     "\n",
-    "To analyse and process speech computationally, we must convert these continuous acoustic signals into a form that reveals their structure To this end, we use various processing techniques that are introduced in this notebook.\n",
+    "To analyse and process speech computationally, we must convert these continuous acoustic signals into a form that reveals their structure. To this end, we use various processing techniques that are introduced in this notebook.\n",
     "\n",
     "1. **Fast Fourier Transform (FFT)**: breaks down the signal into its frequency components\n",
     "2. **Mel-frequency scaling**: scales the frequency components to the Mel-scale, which reflects how humans perceive pitch\n",
@@ -198,7 +198,7 @@
    "source": [
     "This compressed audio preserves all the relevant information (we still understand the word) and consists of only 13 (!) dimensions. In addition, we have 140 columns, each representing the information of a different timepoint of the signal.\n",
     "\n",
-    "In what follows, this notebook explains the concepts underlying this compression. By doing so, it becomes clear that this compression if informed by how humans process speech."
+    "In what follows, this notebook explains the concepts underlying this compression. By doing so, it becomes clear that this compression is informed by how humans process speech."
    ]
   },
   {

--- a/learning-materials/02_byte_pair_encoding.ipynb
+++ b/learning-materials/02_byte_pair_encoding.ipynb
@@ -56,6 +56,23 @@
    ]
   },
   {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "import nltk\n",
+    "nltk.download('gutenberg', quiet=True)"
+   ],
+   "id": "7ab7066b20c97429"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "If the download does not work, use the solution from stackoverflow: https://stackoverflow.com/questions/38916452/nltk-download-ssl-certificate-verify-failed",
+   "id": "d5a07bf5859d36d5"
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "40f9d9b1-6d32-485a-825a-a95392a86d79",
@@ -71,8 +88,6 @@
     }
    ],
    "source": [
-    "import nltk\n",
-    "nltk.download('gutenberg', quiet=True)\n",
     "from nltk.corpus import gutenberg\n",
     "\n",
     "# get text from novel Moby Dick\n",
@@ -184,7 +199,7 @@
     "Often, special tokens are added to the vocabulary for different reasons.\n",
     "- `<|UNK|>` (unknown word) denotes out-of-vocabulary words\n",
     "- `<|endoftext|>` or `<|EOS|>` (end of sequence) are used, among others, when multiple texts such as newspaper articles are concatenated\n",
-    "- `<|beginningoftext|>` or `<|BOS|>` denot beginnings analogous to `<|endoftext|>` and `<|EOS|>`\n",
+    "- `<|beginningoftext|>` or `<|BOS|>` denote beginnings analogous to `<|endoftext|>` and `<|EOS|>`\n",
     "- `<|PAD|>` (padding) is used when training LLMs with batch sizes greater than 1 (i.e., inputs with different length are 'padded' to the length of the longest input; e.g., `['Never', 'mind', '<|PAD|>', '<|PAD|>', '<|PAD|>']` has the same length as `['Actions', 'speak', 'louder', 'than', 'words']`\n",
     "\n",
     "Next, the `<|UNK|>` token is added to our vocabulary. Without this special token, any out-of-vocabulary word would cause errors or be ignored during tokenisation and model inference. Because of this, almost each tokenisation approach uses the `<|UNK|>` token.\n"

--- a/learning-materials/requirements.txt
+++ b/learning-materials/requirements.txt
@@ -4,3 +4,6 @@ numpy
 librosa
 matplotlib
 pyqtgraph
+nltk
+tiktoken
+torch


### PR DESCRIPTION
Hey Hanno,

Here are some small corrections for the learning materials. I updated the `requirements.txt` file and ran all the cells to make sure that the execution works, plus corrected a few minor typos. 

Another thing that caught my attention but that I couldn't add to the pull request:

- the 3rd notebook uses a txt file `the-verdict.txt` which is not currently part of the repo

General remarks:

the learning materials are very high quality, with a lot of detail. Especially the audios and the included images / spectrograms make a lot of sense and make it easier to understand everything.

My main concern is that you might not have enough time in the workshop to show all of it, or at least not with such level of detail (e.g. the code snippets that generate the spectrograms / audios are cool, but I think that most people who come to us will never have to write code like that). 

I think it's also very important to explain how this is relevant for the main topic of the workshop and how it translates into the solutions that are implemented in the video search tool (e.g. which of these transformations are happening at which steps when implementing the video search).

Apart from that, I was also thinking that at least the first notebook could actually be a basis for a separate workshop, e.g. "Fundamentals of speech recognition", as from my perspective it covers quite a large chunk of knowledge that is interesting by itself. 



 