### PR TITLE
Feat/update cuda image

### DIFF
--- a/backend/Dockerfile.gpu
+++ b/backend/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.6.0-runtime-ubuntu22.04
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
 
 # Set environment variables
 # Prevent Python from writing .pyc files (bytecode cache files)
@@ -21,7 +21,7 @@ RUN apt-get update && \
 WORKDIR /app
 
 # Install CUDA-enabled PyTorch
-RUN pip install --no-cache-dir torch torchvision torchaudio
+RUN pip install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
 
 # Copy only requirements.txt to leverage Docker cache
 COPY requirements.txt .


### PR DESCRIPTION
- Older versions (e.g., nvidia/cuda:12.1.0-runtime-ubuntu22.04) are not supported anymore. 
- Newer ones (e.g., nvidia/cuda:12.6.0-runtime-ubuntu22.04) have incompatibility issues with drivers on the host machine.
- `nvidia/cuda:12.2.0-runtime-ubuntu22.04` is the sweet spot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the base Docker image to use a newer CUDA version for GPU support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->